### PR TITLE
Add iOS download banner to hero section

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from "react";
 import { motion } from "framer-motion";
 import FloatingOrbs from "./hero/FloatingOrbs";
 import HeroContent from "./hero/HeroContent";
+import IOSDownloadBanner from "./hero/IOSDownloadBanner";
 import ImageUploader from "./image-editor/ImageUploader";
 import { useMousePosition } from "@/hooks/useMousePosition";
 
@@ -26,7 +27,9 @@ const HeroSection = ({ onImageUploaded }: HeroSectionProps) => {
       className="relative min-h-screen w-full flex flex-col items-center justify-center overflow-hidden px-4 py-20"
     >
       <HeroContent />
-      
+
+      <IOSDownloadBanner />
+
       {/* Always show the ImageUploader, not conditionally */}
       <ImageUploader onImageUpload={handleImageUpload} />
       

--- a/src/components/hero/IOSDownloadBanner.tsx
+++ b/src/components/hero/IOSDownloadBanner.tsx
@@ -1,0 +1,26 @@
+
+import { motion } from "framer-motion";
+import { Smartphone } from "lucide-react";
+
+const IOSDownloadBanner = () => {
+  return (
+    <motion.div
+      className="relative z-10 mt-4 mb-2"
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, delay: 0.4 }}
+    >
+      <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/40 backdrop-blur-sm border border-white/50 text-sm text-gray-600">
+        <Smartphone className="w-4 h-4 text-gray-500" />
+        <span>
+          Download the iOS app
+        </span>
+        <span className="px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 text-xs font-semibold">
+          Coming Soon
+        </span>
+      </div>
+    </motion.div>
+  );
+};
+
+export default IOSDownloadBanner;


### PR DESCRIPTION
## Summary
Added a new iOS download banner component to the hero section that promotes the upcoming iOS app with a "Coming Soon" badge.

## Key Changes
- Created new `IOSDownloadBanner` component (`src/components/hero/IOSDownloadBanner.tsx`)
  - Displays a frosted glass banner with smartphone icon and "Download the iOS app" text
  - Includes a purple "Coming Soon" badge
  - Animated entrance with fade and slide-up effect using Framer Motion
  - Positioned with z-index layering for proper stacking
- Integrated `IOSDownloadBanner` into `HeroSection` component
  - Placed between hero content and image uploader
  - Maintains consistent spacing with margin utilities

## Implementation Details
- Uses Framer Motion for smooth entrance animation (0.6s duration with 0.4s delay)
- Styled with Tailwind CSS using backdrop blur and semi-transparent white background for modern glassmorphism effect
- Leverages Lucide React's `Smartphone` icon for visual consistency
- Component is self-contained and reusable

https://claude.ai/code/session_01B7F7YmzBP4bypLbXEzmrPH